### PR TITLE
Render product category and style price

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import axios from 'axios';
-import { useState, useEffect, useContext } from 'react';
 import Overview from './Overview/Overview.jsx';
 import QuestionsAndAnswers from './QuestionsAndAnswers/QuestionsAndAnswers.jsx';
 import RatingsAndReviews from './RatingsAndReviews/RatingsAndReviews.jsx';

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -10,6 +10,7 @@ function Overview({ currentProduct, currentProductID }) {
   const [isLoading, setIsLoading] = useState(true);
   const [selectedStyle, setSelectedStyle] = useState({});
   const [selectedStylePrice, setSelectedStylePrice] = useState('');
+  const [selectedStyleSalePrice, setSelectedStyleSalePrice] = useState('');
 
 
   // get the styles of the current product
@@ -50,6 +51,8 @@ function Overview({ currentProduct, currentProductID }) {
               setSelectedStyle={setSelectedStyle}
               selectedStylePrice={selectedStylePrice}
               setSelectedStylePrice={setSelectedStylePrice}
+              selectedStyleSalePrice={selectedStyleSalePrice}
+              setSelectedStyleSalePrice={setSelectedStyleSalePrice}
               styles={styles}
             />
           )}

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -43,19 +43,17 @@ function Overview({ currentProduct, currentProductID }) {
           <ImageGallery currentProduct={currentProduct} />
         </div>
         <div className="half">
-          { isLoading ? null : (
-            <ProductInformation
-              currentProduct={currentProduct}
-              currentProductID={currentProductID}
-              selectedStyle={selectedStyle}
-              setSelectedStyle={setSelectedStyle}
-              selectedStylePrice={selectedStylePrice}
-              setSelectedStylePrice={setSelectedStylePrice}
-              selectedStyleSalePrice={selectedStyleSalePrice}
-              setSelectedStyleSalePrice={setSelectedStyleSalePrice}
-              styles={styles}
-            />
-          )}
+          <ProductInformation
+            currentProduct={currentProduct}
+            currentProductID={currentProductID}
+            selectedStyle={selectedStyle}
+            setSelectedStyle={setSelectedStyle}
+            selectedStylePrice={selectedStylePrice}
+            setSelectedStylePrice={setSelectedStylePrice}
+            selectedStyleSalePrice={selectedStyleSalePrice}
+            setSelectedStyleSalePrice={setSelectedStyleSalePrice}
+            styles={styles}
+          />
         </div>
       </div>
     </div>

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
-import React from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import axios from 'axios';
-import { useState, useEffect, useContext } from 'react';
+import PropTypes from 'prop-types';
 import ProductInformation from './ProductInformation.jsx';
 import ImageGallery from './ImageGallery.jsx';
 
@@ -30,20 +30,44 @@ function Overview({ currentProduct, currentProductID }) {
 
   return (
     <div>
-    <div className="container">
-      <div className="half">
-        <ImageGallery currentProduct={currentProduct} />
+      <div className="container">
+        <div className="half">
+          <ImageGallery currentProduct={currentProduct} />
+        </div>
+        <div className="half">
+          <ProductInformation
+            currentProduct={currentProduct}
+            currentProductID={currentProductID}
+            styles={styles}
+          />
+        </div>
       </div>
-      <div className="half">
-        <ProductInformation
-          currentProduct={currentProduct}
-          currentProductID={currentProductID}
-          styles={styles}
-        />
-      </div>
-    </div>
     </div>
   );
 }
+
+Overview.propTypes = {
+  currentProduct: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    slogan: PropTypes.string,
+    description: PropTypes.string,
+    category: PropTypes.string,
+    default_price: PropTypes.string,
+  }),
+  currentProductID: PropTypes.number,
+};
+
+Overview.defaultProps = {
+  currentProduct: {
+    id: '',
+    name: '',
+    slogan: '',
+    description: '',
+    category: '',
+    default_price: '',
+  },
+  currentProductID: '',
+};
 
 export default Overview;

--- a/client/src/components/Overview/Overview.jsx
+++ b/client/src/components/Overview/Overview.jsx
@@ -7,8 +7,14 @@ import ImageGallery from './ImageGallery.jsx';
 
 function Overview({ currentProduct, currentProductID }) {
   const [styles, setStyles] = useState({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedStyle, setSelectedStyle] = useState({});
+  const [selectedStylePrice, setSelectedStylePrice] = useState('');
+
+
   // get the styles of the current product
   const loadProductStyles = () => {
+    setIsLoading(true);
     const options = {
       url: '/api/product/styles',
       params: {
@@ -23,11 +29,12 @@ function Overview({ currentProduct, currentProductID }) {
     })
       .then((response) => {
         setStyles(response.data);
+        setSelectedStyle(response.data[0]);
+        setIsLoading(false);
       })
       .catch((error) => console.log('Error', error.message));
   };
   useEffect(loadProductStyles, [currentProductID]);
-
   return (
     <div>
       <div className="container">
@@ -35,11 +42,17 @@ function Overview({ currentProduct, currentProductID }) {
           <ImageGallery currentProduct={currentProduct} />
         </div>
         <div className="half">
-          <ProductInformation
-            currentProduct={currentProduct}
-            currentProductID={currentProductID}
-            styles={styles}
-          />
+          { isLoading ? null : (
+            <ProductInformation
+              currentProduct={currentProduct}
+              currentProductID={currentProductID}
+              selectedStyle={selectedStyle}
+              setSelectedStyle={setSelectedStyle}
+              selectedStylePrice={selectedStylePrice}
+              setSelectedStylePrice={setSelectedStylePrice}
+              styles={styles}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/Overview/ProductInformation.jsx
+++ b/client/src/components/Overview/ProductInformation.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import StyleSelector from './StyleSelector.jsx';
 
 function ProductInformation({
-  currentProduct, currentProductID, styles, selectedStyle, setSelectedStyle,selectedStylePrice, setSelectedStylePrice
+  currentProduct, currentProductID, styles, selectedStyle, setSelectedStyle, selectedStylePrice, setSelectedStylePrice, selectedStyleSalePrice, setSelectedStyleSalePrice
 }) {
   const [stylesArray, setStylesArray] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -14,14 +14,27 @@ function ProductInformation({
     setSelectedIsLoading(true);
 
     setSelectedIsLoading(false);
-
   };
   useEffect(loadStyles, [currentProduct, selectedStyle]);
-
+  const salePrice = { color: 'red' };
+  const element = <span style={salePrice}>{selectedStyleSalePrice}</span>;
   return (
     <div>
       <h1>{ currentProduct.name }</h1>
-      <h3>{ selectedStylePrice }</h3>
+      {selectedStyleSalePrice ? (
+        <span>
+          <s>{ selectedStylePrice }</s>
+          {' '}
+          <span>
+            { element }
+          </span>
+        </span>
+      ) : (
+        <span>
+          { selectedStylePrice }
+        </span>
+      )}
+
       <h3>{ currentProduct.category }</h3>
       <h3>{ currentProduct.description }</h3>
 
@@ -32,6 +45,8 @@ function ProductInformation({
           setSelectedStyle={setSelectedStyle}
           selectedStylePrice={selectedStylePrice}
           setSelectedStylePrice={setSelectedStylePrice}
+          selectedStyleSalePrice={selectedStyleSalePrice}
+          setSelectedStyleSalePrice={setSelectedStyleSalePrice}
         />
       </div>
 

--- a/client/src/components/Overview/ProductInformation.jsx
+++ b/client/src/components/Overview/ProductInformation.jsx
@@ -18,6 +18,7 @@ function ProductInformation({ currentProduct, currentProductID, styles }) {
   return (
     <div>
       <h1>{ currentProduct.name }</h1>
+      <h3>{ currentProduct.category }</h3>
       <h3>{ currentProduct.description }</h3>
 
       <div className="styleSelectorContainer">

--- a/client/src/components/Overview/ProductInformation.jsx
+++ b/client/src/components/Overview/ProductInformation.jsx
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import React, { useState, useEffect, useContext } from 'react';
+import PropTypes from 'prop-types';
 import StyleEntry from './StyleEntry.jsx';
 
 function ProductInformation({ currentProduct, currentProductID, styles }) {
@@ -22,8 +22,8 @@ function ProductInformation({ currentProduct, currentProductID, styles }) {
 
       <div className="styleSelectorContainer">
         {stylesArray ? stylesArray.map((style, index) => (
-          <div className="styleEntry" data-testid="styleEntry">
-            <StyleEntry style={style} key={index} index={index} />
+          <div className="styleEntry" data-testid="styleEntry" key={index}>
+            <StyleEntry style={style} index={index} />
           </div>
         )) : null}
       </div>
@@ -31,5 +31,46 @@ function ProductInformation({ currentProduct, currentProductID, styles }) {
     </div>
   );
 }
+
+ProductInformation.propTypes = {
+  currentProduct: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    slogan: PropTypes.string,
+    description: PropTypes.string,
+    category: PropTypes.string,
+    default_price: PropTypes.string,
+  }),
+  currentProductID: PropTypes.number,
+  styles: PropTypes.shape({
+    product_id: PropTypes.string,
+    results: PropTypes.arrayOf(
+      PropTypes.shape({
+        'style_id': PropTypes.number,
+        'name': PropTypes.string,
+        'original_price': PropTypes.string,
+        'sale_price': PropTypes.string,
+        'default?': PropTypes.bool,
+      }),
+    ),
+    skus: PropTypes.shape(PropTypes.shape({
+      'quantity': PropTypes.number,
+      'size': PropTypes.string,
+    })),
+  }),
+};
+
+ProductInformation.defaultProps = {
+  currentProduct: {
+    id: '',
+    name: '',
+    slogan: '',
+    description: '',
+    category: '',
+    default_price: '',
+  },
+  currentProductID: '',
+  styles: {},
+};
 
 export default ProductInformation;

--- a/client/src/components/Overview/ProductInformation.jsx
+++ b/client/src/components/Overview/ProductInformation.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import StyleSelector from './StyleSelector.jsx';
 
 function ProductInformation({
-  currentProduct, currentProductID, styles, selectedStyle, setSelectedStyle, selectedStylePrice, setSelectedStylePrice, selectedStyleSalePrice, setSelectedStyleSalePrice
+  currentProduct, currentProductID, styles, selectedStyle,
+  setSelectedStyle, selectedStylePrice, setSelectedStylePrice,
+  selectedStyleSalePrice, setSelectedStyleSalePrice,
 }) {
   const [stylesArray, setStylesArray] = useState([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/client/src/components/Overview/ProductInformation.jsx
+++ b/client/src/components/Overview/ProductInformation.jsx
@@ -1,32 +1,38 @@
 import React, { useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
-import StyleEntry from './StyleEntry.jsx';
+import StyleSelector from './StyleSelector.jsx';
 
-function ProductInformation({ currentProduct, currentProductID, styles }) {
+function ProductInformation({
+  currentProduct, currentProductID, styles, selectedStyle, setSelectedStyle,selectedStylePrice, setSelectedStylePrice
+}) {
   const [stylesArray, setStylesArray] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [selectedIsLoading, setSelectedIsLoading] = useState(true);
+
   // load the stylesArray with styles
   const loadStyles = () => {
-    setStylesArray(styles.results);
-    setIsLoading(false);
-  };
-  useEffect(loadStyles, [styles, stylesArray]);
+    setSelectedIsLoading(true);
 
-  if (isLoading) {
-    return null;
-  }
+    setSelectedIsLoading(false);
+
+  };
+  useEffect(loadStyles, [currentProduct, selectedStyle]);
+
   return (
     <div>
       <h1>{ currentProduct.name }</h1>
+      <h3>{ selectedStylePrice }</h3>
       <h3>{ currentProduct.category }</h3>
       <h3>{ currentProduct.description }</h3>
 
       <div className="styleSelectorContainer">
-        {stylesArray ? stylesArray.map((style, index) => (
-          <div className="styleEntry" data-testid="styleEntry" key={index}>
-            <StyleEntry style={style} index={index} />
-          </div>
-        )) : null}
+        <StyleSelector
+          stylesArray={styles.results}
+          selectedStyle={selectedStyle}
+          setSelectedStyle={setSelectedStyle}
+          selectedStylePrice={selectedStylePrice}
+          setSelectedStylePrice={setSelectedStylePrice}
+        />
       </div>
 
     </div>

--- a/client/src/components/Overview/ProductInformation.test.jsx
+++ b/client/src/components/Overview/ProductInformation.test.jsx
@@ -292,3 +292,10 @@ describe('render price', (done) => {
     }, 500);
   });
 });
+describe('render category', () => {
+  it('renders the category of the product', () => {
+    render(<Overview currentProduct={products[0]} currentProductID={1} />);
+    const category = screen.getByText('Jackets');
+    expect(category).toBeTruthy();
+  });
+});

--- a/client/src/components/Overview/ProductInformation.test.jsx
+++ b/client/src/components/Overview/ProductInformation.test.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { render, screen, wrapper } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import ProductInformation from './ProductInformation.jsx';
 import StyleEntry from './StyleEntry.jsx';
 import Overview from './Overview.jsx';
@@ -32,12 +32,12 @@ const styles = {
   product_id: '1',
   results: [
     {
-      style_id: 1,
-      name: 'Forest Green & Black',
-      original_price: '140',
-      sale_price: '0',
+      'style_id': 1,
+      'name': 'Forest Green & Black',
+      'original_price': '140',
+      'sale_price': '0',
       'default?': true,
-      photos: [
+      'photos': [
         {
           thumbnail_url: 'urlplaceholder/style_1_photo_number_thumbnail.jpg',
           url: 'urlplaceholder/style_1_photo_number.jpg',
@@ -47,7 +47,7 @@ const styles = {
           url: 'urlplaceholder/style_1_photo_number.jpg',
         },
       ],
-      skus: {
+      'skus': {
         37: {
           quantity: 8,
           size: 'XS',
@@ -63,18 +63,18 @@ const styles = {
       },
     },
     {
-      style_id: 2,
-      name: 'Desert Brown & Tan',
-      original_price: '140',
-      sale_price: '0',
+      'style_id': 2,
+      'name': 'Desert Brown & Tan',
+      'original_price': '140',
+      'sale_price': '0',
       'default?': false,
-      photos: [
+      'photos': [
         {
           thumbnail_url: 'urlplaceholder/style_2_photo_number_thumbnail.jpg',
           url: 'urlplaceholder/style_2_photo_number.jpg',
         },
       ],
-      skus: {
+      'skus': {
         37: {
           quantity: 8,
           size: 'XS',
@@ -95,12 +95,12 @@ const styles2 = {
   product_id: '2',
   results: [
     {
-      style_id: 1,
-      name: 'Forest Green & Black',
-      original_price: '140',
-      sale_price: '0',
+      'style_id': 1,
+      'name': 'Forest Green & Black',
+      'original_price': '140',
+      'sale_price': '0',
       'default?': true,
-      photos: [
+      'photos': [
         {
           thumbnail_url: 'urlplaceholder/style_1_photo_number_thumbnail.jpg',
           url: 'urlplaceholder/style_1_photo_number.jpg',
@@ -110,7 +110,7 @@ const styles2 = {
           url: 'urlplaceholder/style_1_photo_number.jpg',
         },
       ],
-      skus: {
+      'skus': {
         37: {
           quantity: 8,
           size: 'XS',
@@ -126,18 +126,18 @@ const styles2 = {
       },
     },
     {
-      style_id: 2,
-      name: 'Desert Brown & Tan',
-      original_price: '140',
-      sale_price: '0',
+      'style_id': 2,
+      'name': 'Desert Brown & Tan',
+      'original_price': '140',
+      'sale_price': '0',
       'default?': false,
-      photos: [
+      'photos': [
         {
           thumbnail_url: 'urlplaceholder/style_2_photo_number_thumbnail.jpg',
           url: 'urlplaceholder/style_2_photo_number.jpg',
         },
       ],
-      skus: {
+      'skus': {
         37: {
           quantity: 8,
           size: 'XS',
@@ -153,18 +153,18 @@ const styles2 = {
       },
     },
     {
-      style_id: 3,
-      name: 'Ocean Blue & Gray',
-      original_price: '140',
-      sale_price: '0',
+      'style_id': 3,
+      'name': 'Ocean Blue & Gray',
+      'original_price': '140',
+      'sale_price': '0',
       'default?': false,
-      photos: [
+      'photos': [
         {
           thumbnail_url: 'urlplaceholder/style_3_photo_number_thumbnail.jpg',
           url: 'urlplaceholder/style_3_photo_number.jpg',
         },
       ],
-      skus: {
+      'skus': {
         37: {
           quantity: 8,
           size: 'XS',

--- a/client/src/components/Overview/ProductInformation.test.jsx
+++ b/client/src/components/Overview/ProductInformation.test.jsx
@@ -35,7 +35,7 @@ const styles = {
       'style_id': 1,
       'name': 'Forest Green & Black',
       'original_price': '140',
-      'sale_price': '0',
+      'sale_price': '100',
       'default?': true,
       'photos': [
         {
@@ -181,8 +181,8 @@ const styles2 = {
     }],
 };
 describe('Overview component', () => {
-  it('Overview component contains ImageGallery component', () => {
-    render(<Overview
+  it('Overview component contains ImageGallery component', async () => {
+    await render(<Overview
       currentProduct={products[0]}
       currentProductID={1}
     />);
@@ -272,5 +272,23 @@ describe('style thumbnails', () => {
 
     const element = screen.getAllByTestId('styleEntry');
     expect(element).toHaveLength(3);
+  });
+});
+describe('render price', (done) => {
+  it('renders the original price of the style', () => {
+    render(<Overview currentProduct={products[0]} currentProductID={1} />);
+    setTimeout(() => {
+      const originalPrice = screen.getByText('140');
+      expect(originalPrice).toBeTruthy();
+      done();
+    }, 500);
+  });
+  it('renders the sales price of the style', () => {
+    render(<Overview currentProduct={products[0]} currentProductID={1} />);
+    setTimeout(() => {
+      const salePrice = screen.getByText('100');
+      expect(salePrice).toBeTruthy();
+      done();
+    }, 500);
   });
 });

--- a/client/src/components/Overview/StyleEntry.jsx
+++ b/client/src/components/Overview/StyleEntry.jsx
@@ -1,8 +1,10 @@
 import axios from 'axios';
 import React, { useState, useEffect, useContext } from 'react';
 
-function styleEntry({ style, selectedStyle, setSelectedStyle }) {
-
+function styleEntry({
+  style, selectedStyle, setSelectedStyle,
+  selectedStyleSalePrice, setSelectedStyleSalePrice
+}) {
   return (
     <div>
       <img className="styleEntryThumbnail" src={style.photos[0].thumbnail_url} alt={style.name} />

--- a/client/src/components/Overview/StyleEntry.jsx
+++ b/client/src/components/Overview/StyleEntry.jsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import React, { useState, useEffect, useContext } from 'react';
 
-function styleEntry({ style }) {
+function styleEntry({ style, selectedStyle, setSelectedStyle }) {
+
   return (
     <div>
       <img className="styleEntryThumbnail" src={style.photos[0].thumbnail_url} alt={style.name} />

--- a/client/src/components/Overview/StyleSelector.jsx
+++ b/client/src/components/Overview/StyleSelector.jsx
@@ -2,12 +2,15 @@ import React, { useState, useEffect, useContext } from 'react';
 import StyleEntry from './StyleEntry.jsx';
 import Promise from 'bluebird';
 
-function styleSelector({ stylesArray, selectedStyle, setSelectedStyle,  selectedStylePrice, setSelectedStylePrice}) {
+function styleSelector({
+  stylesArray, selectedStyle, setSelectedStyle,
+  selectedStylePrice, setSelectedStylePrice, selectedStyleSalePrice, setSelectedStyleSalePrice,
+}) {
   const [isLoading, setIsLoading] = useState(true);
   // load the stylesArray with styles
   const loadStyles = () => {
     setIsLoading(true);
-    function getPrice() {
+    function getOriginalPrice() {
       let didSucceed = false;
       return new Promise((resolve, reject) => {
         if (typeof stylesArray !== 'undefined') {
@@ -18,15 +21,37 @@ function styleSelector({ stylesArray, selectedStyle, setSelectedStyle,  selected
         if (didSucceed === true) {
           resolve(stylesArray[0].original_price);
         } else {
-          reject(new Error('Not done Loading'));
+          reject(new Error('Not done loading'));
         }
       });
     }
 
-    getPrice()
-      .then((data) => { setSelectedStylePrice(data)});
+    getOriginalPrice()
+      .then((data) => { setSelectedStylePrice(data); });
+
+    function getSalePrice() {
+      let didSucceed = false;
+      return new Promise((resolve, reject) => {
+        if (typeof stylesArray !== 'undefined') {
+          if (stylesArray.length > 0) {
+            didSucceed = true;
+          }
+        }
+        if (didSucceed === true) {
+          resolve(stylesArray[0].sale_price);
+        } else {
+          reject(new Error('Not done loading'));
+        }
+      });
+    }
+    getSalePrice()
+      .then((data) => { setSelectedStyleSalePrice(data); });
     setIsLoading(false);
   };
+
+
+
+
   useEffect(loadStyles, [stylesArray]);
   return (
     <div>
@@ -40,6 +65,8 @@ function styleSelector({ stylesArray, selectedStyle, setSelectedStyle,  selected
             setSelectedStyle={setSelectedStyle}
             selectedStylePrice={selectedStylePrice}
             setSelectedStylePrice={setSelectedStylePrice}
+            selectedStyleSalePrice={selectedStyleSalePrice}
+            setSelectedStyleSalePrice={setSelectedStyleSalePrice}
           />
         </div>
       )) : null}

--- a/client/src/components/Overview/StyleSelector.jsx
+++ b/client/src/components/Overview/StyleSelector.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect, useContext } from 'react';
+import StyleEntry from './StyleEntry.jsx';
+import Promise from 'bluebird';
+
+function styleSelector({ stylesArray, selectedStyle, setSelectedStyle,  selectedStylePrice, setSelectedStylePrice}) {
+  const [isLoading, setIsLoading] = useState(true);
+  // load the stylesArray with styles
+  const loadStyles = () => {
+    setIsLoading(true);
+    function getPrice() {
+      let didSucceed = false;
+      return new Promise((resolve, reject) => {
+        if (typeof stylesArray !== 'undefined') {
+          if (stylesArray.length > 0) {
+            didSucceed = true;
+          }
+        }
+        if (didSucceed === true) {
+          resolve(stylesArray[0].original_price);
+        } else {
+          reject(new Error('Not done Loading'));
+        }
+      });
+    }
+
+    getPrice()
+      .then((data) => { setSelectedStylePrice(data)});
+    setIsLoading(false);
+  };
+  useEffect(loadStyles, [stylesArray]);
+  return (
+    <div>
+      {stylesArray ? stylesArray.map((style, index) => (
+        <div className="styleEntry" data-testid="styleEntry" key={index}>
+          <StyleEntry
+            style={style}
+            index={index}
+            stylesArray={stylesArray}
+            selectedStyle={selectedStyle}
+            setSelectedStyle={setSelectedStyle}
+            selectedStylePrice={selectedStylePrice}
+            setSelectedStylePrice={setSelectedStylePrice}
+          />
+        </div>
+      )) : null}
+    </div>
+  );
+}
+
+export default styleSelector;

--- a/client/src/components/Overview/StyleSelector.jsx
+++ b/client/src/components/Overview/StyleSelector.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
-import StyleEntry from './StyleEntry.jsx';
 import Promise from 'bluebird';
+import StyleEntry from './StyleEntry.jsx';
 
 function styleSelector({
   stylesArray, selectedStyle, setSelectedStyle,
@@ -44,13 +44,11 @@ function styleSelector({
         }
       });
     }
+
     getSalePrice()
       .then((data) => { setSelectedStyleSalePrice(data); });
     setIsLoading(false);
   };
-
-
-
 
   useEffect(loadStyles, [stylesArray]);
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.4.0",
         "babel-loader": "^9.1.3",
+        "bluebird": "^3.7.2",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "nodemon": "^3.0.1",
@@ -4014,6 +4015,11 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
       "version": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "axios": "^1.4.0",
     "babel-loader": "^9.1.3",
+    "bluebird": "^3.7.2",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "nodemon": "^3.0.1",


### PR DESCRIPTION
- renders product category
- renders the style's original price
- if the style has a sale price, it crosses the original price out, and renders the style's sale price in red next to the original price
- added tests to test for product category and style prices
- added bluebird to package.json

For an example of crossed out original price and sale price, change line 41 of StyleSelector.jsx from ` resolve(stylesArray[0].sale_price);` to ` resolve(stylesArray[2].sale_price);`