### PR TITLE
create modal components to be shared, tests for ReviewList

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -9,5 +9,8 @@ body {
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
   }
+}
 
+.overflow-y-hidden {
+  overflow: hidden;
 }

--- a/client/src/components/RatingsAndReviews/RatingsAndReviews.jsx
+++ b/client/src/components/RatingsAndReviews/RatingsAndReviews.jsx
@@ -14,7 +14,7 @@ function RatingsAndReviews({ currentProductID }) {
   React.useEffect(() => {
     axios.get('/reviews', {
       params: {
-        product_id: currentProductID,
+        product_id: 40345,
       },
     })
       .then((response) => setReviews(response.data.results))
@@ -23,7 +23,7 @@ function RatingsAndReviews({ currentProductID }) {
   React.useEffect(() => {
     axios.get('/reviews/meta', {
       params: {
-        product_id: currentProductID,
+        product_id: 40345,
       },
     })
       .then((response) => setMetaData(response.data))

--- a/client/src/components/RatingsAndReviews/RatingsGraph.jsx
+++ b/client/src/components/RatingsAndReviews/RatingsGraph.jsx
@@ -8,27 +8,27 @@ function RatingsGraph({ metaData }) {
     <div data-testid="ratings-graph-component">
       <BarFormat>
         <StarSpan>5 stars</StarSpan>
-        <BarDisplay metadata={metaData} rating="5" />
+        <BarDisplay $metadata={metaData} $rating="5" />
         <ReviewSpan>{`(${metaData['5']})`}</ReviewSpan>
       </BarFormat>
       <BarFormat>
         <StarSpan>4 stars</StarSpan>
-        <BarDisplay metadata={metaData} rating="4" />
+        <BarDisplay $metadata={metaData} $rating="4" />
         <ReviewSpan>{`(${metaData['4']})`}</ReviewSpan>
       </BarFormat>
       <BarFormat>
         <StarSpan>3 stars</StarSpan>
-        <BarDisplay metadata={metaData} rating="3" />
+        <BarDisplay $metadata={metaData} $rating="3" />
         <ReviewSpan>{`(${metaData['3']})`}</ReviewSpan>
       </BarFormat>
       <BarFormat>
         <StarSpan>2 stars</StarSpan>
-        <BarDisplay metadata={metaData} rating="2" />
+        <BarDisplay $metadata={metaData} $rating="2" />
         <ReviewSpan>{`(${metaData['2']})`}</ReviewSpan>
       </BarFormat>
       <BarFormat>
         <StarSpan>1 stars</StarSpan>
-        <BarDisplay metadata={metaData} rating="1" />
+        <BarDisplay $metadata={metaData} $rating="1" />
         <ReviewSpan>{`(${metaData['1']})`}</ReviewSpan>
       </BarFormat>
     </div>
@@ -50,8 +50,8 @@ const StarSpan = styled.span`
   cursor: pointer;`;
 const BarDisplay = styled.div`
   background: linear-gradient(90deg,
-    black ${({ metadata, rating }) => calculatePercentage(metadata, rating)}%,
-    lightgrey ${({ metadata, rating }) => calculatePercentage(metadata, rating)}%);
+    black ${({ $metadata, $rating }) => calculatePercentage($metadata, $rating)}%,
+    lightgrey ${({ $metadata, $rating }) => calculatePercentage($metadata, $rating)}%);
   height: 10px;
   width: 200px;`;
 const ReviewSpan = styled.span`

--- a/client/src/components/RatingsAndReviews/ReviewList.jsx
+++ b/client/src/components/RatingsAndReviews/ReviewList.jsx
@@ -1,23 +1,86 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Review from './Review.jsx';
+import {
+  StyledButton, ModalWrapper, Modal, ModalContent,
+} from '../../styled-components/common-elements.jsx';
 
 function ReviewList({ reviews }) {
+  const [displayedReviews, setDisplayedReviews] = React.useState(2);
+  const [remainingReviews, setRemainingReviews] = React.useState(0);
+  const [clickCount, setClickCount] = React.useState(0);
+  const [displayModal, setDisplayModal] = React.useState(false);
+  React.useEffect(() => setRemainingReviews(reviews.length - 2), [reviews]);
+  // eslint-disable-next-line func-names
+  const handleClick = function (e) {
+    if (clickCount < 1) {
+      e.preventDefault();
+      setDisplayedReviews((prev) => prev + 2);
+      setRemainingReviews((prev) => prev - 2);
+      setClickCount((prev) => prev + 1);
+    } else {
+      setDisplayModal(true);
+    }
+  };
+  React.useEffect(() => {
+    if (displayModal) {
+      document.body.classList.add('overflow-y-hidden');
+    } else {
+      document.body.classList.remove('overflow-y-hidden');
+    }
+  }, [displayModal]);
+
   return (
-    <div style={{ 'paddingTop': '20px' }} data-testid="reviewList-component">
+    <div
+      style={{ 'paddingTop': '20px' }}
+      data-testid="reviewList-component"
+    >
       <label htmlFor="dropdown">
-        Sort By:
+        {'Sort By: '}
         <select id="dropdown">
+          <option value="relevant">Relevant</option>
           <option value="helpful">Helpful</option>
           <option value="newest">Newest</option>
-          <option value="relevant">Relevant</option>
         </select>
       </label>
       <div style={{ 'paddingTop': '20px' }}>
-        {reviews.length ? reviews.map((review) => <Review key={review.review_id} review={review} />)
-          : <h1>Loading...</h1>}
+        {
+        reviews.length
+          ?
+          reviews.slice(0, displayedReviews).map((review) =>
+            <Review key={review.review_id} review={review} />)
+          : <h1>Be the first to add a review!</h1>
+        }
       </div>
-      <button type="submit">Show More Reviews</button>
+      <div style={{ 'display': 'flex', 'justifyContent': 'center' }}>
+        { remainingReviews > 0 && (
+        <StyledButton
+          data-testid="reviewList-button"
+          type="button"
+          onClick={(e) => handleClick(e)}
+        >
+          Show More Reviews
+        </StyledButton>
+        )}
+      </div>
+      <ModalWrapper $displaymodal={displayModal}>
+        <Modal $displaymodal={displayModal}>
+          <h1 data-testid="reviewList-modal">Reviews</h1>
+          <ModalContent $displaymodal={displayModal}>
+            {
+            reviews.length && reviews.map((review) =>
+              <Review key={review.review_id} review={review} />)
+            }
+          </ModalContent>
+          <StyledButton
+            style={{ 'width': '150px' }}
+            type="button"
+            onClick={() => setDisplayModal(false)}
+          >
+            Close
+          </StyledButton>
+        </Modal>
+      </ModalWrapper>
     </div>
   );
 }

--- a/client/src/components/RatingsAndReviews/ReviewList.test.js
+++ b/client/src/components/RatingsAndReviews/ReviewList.test.js
@@ -1,16 +1,23 @@
 /** @jest-environment jsdom */
 /* eslint-env jest */
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import ReviewList from './ReviewList.jsx';
 import data from './exampleData.json';
 
 describe('ReviewList Component', () => {
   const reviews = data.results;
-  render(<ReviewList reviews={reviews} />);
-  const title = screen.getByTestId('reviewList-component');
-
   test('Component rendered', () => {
+    render(<ReviewList reviews={reviews} />);
+    const title = screen.getByTestId('reviewList-component');
     expect(title).toBeTruthy();
+  });
+  test('Modal rendered', () => {
+    render(<ReviewList reviews={reviews} />);
+    const button = screen.getByTestId('reviewList-button');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    const modal = screen.getByTestId('reviewList-modal');
+    expect(modal).toBeTruthy();
   });
 });

--- a/client/src/components/RatingsAndReviews/exampleData.json
+++ b/client/src/components/RatingsAndReviews/exampleData.json
@@ -34,6 +34,66 @@
       "reviewer_name": "bigbrotherbenjamin",
       "helpfulness": 5,
       "photos": []
+    },
+    {
+      "review_id": 6,
+      "rating": 3,
+      "summary": "I'm enjoying wearing these shades",
+      "recommend": false,
+      "response": null,
+      "body": "Comfortable and practical.",
+      "date": "2019-04-14T00:00:00.000Z",
+      "reviewer_name": "shortandsweeet",
+      "helpfulness": 5,
+      "photos": [{
+          "id": 1,
+          "url": "urlplaceholder/review_5_photo_number_1.jpg"
+        },
+        {
+          "id": 2,
+          "url": "urlplaceholder/review_5_photo_number_2.jpg"
+        }
+      ]
+    },
+    {
+      "review_id": 7,
+      "rating": 3,
+      "summary": "I'm enjoying wearing these shades",
+      "recommend": false,
+      "response": null,
+      "body": "Comfortable and practical.",
+      "date": "2019-04-14T00:00:00.000Z",
+      "reviewer_name": "shortandsweeet",
+      "helpfulness": 5,
+      "photos": [{
+          "id": 1,
+          "url": "urlplaceholder/review_5_photo_number_1.jpg"
+        },
+        {
+          "id": 2,
+          "url": "urlplaceholder/review_5_photo_number_2.jpg"
+        }
+      ]
+    },
+    {
+      "review_id": 8,
+      "rating": 3,
+      "summary": "I'm enjoying wearing these shades",
+      "recommend": false,
+      "response": null,
+      "body": "Comfortable and practical.",
+      "date": "2019-04-14T00:00:00.000Z",
+      "reviewer_name": "shortandsweeet",
+      "helpfulness": 5,
+      "photos": [{
+          "id": 1,
+          "url": "urlplaceholder/review_5_photo_number_1.jpg"
+        },
+        {
+          "id": 2,
+          "url": "urlplaceholder/review_5_photo_number_2.jpg"
+        }
+      ]
     }
   ]
 }

--- a/client/src/styled-components/common-elements.jsx
+++ b/client/src/styled-components/common-elements.jsx
@@ -35,5 +35,41 @@ const StyledButton = styled.button`
   color: white;
   background: black;
   cursor: pointer`;
+// $displaymodal is the boolean prop passed into the modal components to determine visibility
+const ModalWrapper = styled.div`
+  display: ${({ $displaymodal }) => ($displaymodal ? 'flex' : 'none')};
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);`;
 
-export { StarView, StyledButton };
+const Modal = styled.div`
+  display: ${({ $displaymodal }) => ($displaymodal ? 'flex' : 'none')};
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #fefefe;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%;
+  height: 85%;`;
+
+const ModalContent = styled.div`
+  display: ${({ $displaymodal }) => ($displaymodal ? 'block' : 'none')};
+  background-color: #fefefe;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 90%;
+  max-height: calc(80vh - 20vh);
+  overflow-y: auto;
+  overscroll-behavior: contain;`;
+
+export {
+  StarView, StyledButton, ModalWrapper, Modal, ModalContent,
+};


### PR DESCRIPTION
- Modal styled-components comprise of the ModalWrapper (dims the background), the Modal itself (can place things you don't want to be scrolled), and ModalContent (the content you do want to scroll) inside of the common-elements file. They take in a boolean prop '$displaymodal' to determine visibility.

- Added a useEffect that will toggle a class on the document body so that when the modal is visible, the page in the background cannot be scroll.

- Added a class in the css to handle conditional scrolling abilities.
